### PR TITLE
Fix build producing empty binary

### DIFF
--- a/.cargo/config
+++ b/.cargo/config
@@ -1,2 +1,6 @@
 [build]
 target = "thumbv7em-none-eabihf"
+[target.'cfg(all(target_arch = "arm", target_os = "none"))']
+rustflags = [
+  "-C", "link-arg=-Tlink.x",
+]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,16 +5,29 @@ version = "0.1.0"
 edition = "2018"
 
 [dependencies]
+cortex-m = "0.5.8"
 cortex-m-rt = "0.6.7"
-nrf52832-hal = "0.6"
-nrf52832-pac = "0.6"
 # cortex-m-rtfm = "0.4"
 # panic-semihosting = "0.5"
 panic-halt = "0.2.0"
-# cortex-m-semihosting = "0.3"
 
-[profile.dev]
-panic = "abort"
+[dependencies.nrf52832-pac]
+version = "0.6"
+optional = true
+default-features = false
+
+[dependencies.nrf52832-hal]
+version = "0.6"
+optional = true
+default-features = false
+
+[features]
+52832 = ["nrf52832-hal", "nrf52832-pac"]
+default = ["52832"]
 
 [profile.release]
 panic = "abort"
+codegen-units = 1 # better optimizations
+debug = true # symbols are nice and they don't increase the size on Flash
+lto = true # better optimizations
+

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,5 +1,6 @@
 #![no_std]
 #![no_main]
+
 use cortex_m_rt::entry;
 #[allow(unused)]
 use panic_halt;
@@ -7,7 +8,7 @@ use panic_halt;
 
 #[entry]
 fn main() -> ! {
-    loop {
-        continue;
-    }
+    cortex_m::asm::nop(); // To not have main optimize to abort in release mode, remove when you add code
+
+    loop {}
 }


### PR DESCRIPTION
```bash
arm-none-eabi-size target/thumbv7em-none-eabihf/release/rust-embedded
   text	   data	    bss	    dec	    hex	filename
   1660	      0	      0	   1660	    67c	target/thumbv7em-none-eabihf/release/rust-embedded
```

```
(gdb) load
Loading section .vector_table, size 0x400 lma 0x0
Loading section .text, size 0x27c lma 0x400
Start address 0x406, load size 1660
Transfer rate: 147 KB/sec, 830 bytes/write.
```